### PR TITLE
feat: use docker-compose to run codspeed in the CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,12 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-        with:
-          python-version: '3.10'
-      - run: pip install -r requirements.txt
-
-      - uses: CodSpeedHQ/action@feat/tokenless-upload
-        with:
-          upload_url: https://api.staging.preview.codspeed.io/upload
-          run: pytest tests/ --codspeed
+      - name: Run CodSpeed in docker
+        run: |
+          # create .env file with the content of the `env` command
+          env > .env
+          # build the image
+          docker buildx build . -t python-image
+          # run the container with a long running command, in privileged mode and bind the event.json file
+          docker run -d --privileged --name python -v /home/runner/work/_temp/_github_workflow/event.json:/home/runner/work/_temp/_github_workflow/event.json python-image tail -f /dev/null
+          # run codspeed in the container
+          docker exec --env-file .env python sh -c "/root/.cargo/bin/codspeed run -- pytest tests/ --codspeed"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use the official Python image from the Docker Hub
+FROM python:3.12
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container
+COPY requirements.txt .
+
+# Install the dependencies
+RUN pip install -r requirements.txt
+
+# Copy the rest of the application code into the container
+COPY --chown=root:root . .
+
+# Set the RUNNER_VERSION environment variable
+ENV RUNNER_VERSION=3.2.1
+
+# Install the CodSpeed runner
+RUN curl -fsSL https://github.com/CodSpeedHQ/runner/releases/download/v$RUNNER_VERSION/codspeed-runner-installer.sh | sh -s

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pytest~=7.1.3
 pytest-benchmark~=3.4.1
-pytest-codspeed~=1.1.0
+pytest-codspeed~=3.1.0


### PR DESCRIPTION
# Use docker to run CodeSpeed in CI

## Things to note
- Use the latest version of https://github.com/CodSpeedHQ/pytest-codspeed: `3.10`
- The `Dockerfile` installs https://github.com/CodSpeedHQ/runner: `3.2.1
- In the GitHub Actions workflow:
  - The `env` is copied to a file and passed to the `docker run` command
  - The container runs with privileged mode
  - The file `/home/runner/work/_temp/_github_workflow/event.json` is mounted in the container